### PR TITLE
CouchDB Harvester for Richard's couchdb twitter repo

### DIFF
--- a/twitter_harvester_archived_tweets.py
+++ b/twitter_harvester_archived_tweets.py
@@ -89,7 +89,7 @@ def harvest_cloud_city_tweets(city, tp):
 	print('harvesting tweets for city: ', city)
 
 	res = retrieve_tweets(city, start_year, start_month, start_day, now.year, now.month, now.day, max_id)
-	print(res)
+	# print(res)
 	if res == None or 'rows' not in res:
 		print("Cannot retrieve tweets for ", city)
 		return None


### PR DESCRIPTION
To run, use "cloud" as an argument

For example. 

"python run.py cloud stream" means you run both the stream harvester and cloud harvester. 